### PR TITLE
Modifies folio_api to use folioAccessToken in cookie headers.

### DIFF
--- a/files/folio_api.php
+++ b/files/folio_api.php
@@ -2,112 +2,105 @@
 
 require_once 'config.php';
 
-
-
 ### Functions ###
-
 function parse_http_response($response, $curl_info, $lc_header_names = true) {
-
   $parsed_response = array();
   $parsed_response['headers'] = array();
-
-
+  
   // Set status code in parsed response.
   $parsed_response['status_code'] = $curl_info['http_code'];
-
-  // Store header portion of response in array for parsing.
   $header = substr($response, 0, $curl_info['header_size']);
   $header_arr = explode("\r\n", $header);
 
-  // Parse header array into associative array with header names and values.
-  $header_count = count($header_arr);
-
-  for ($i = 1; $i < $header_count; $i++) {
+  for ($i = 1; $i < count($header_arr); $i++) {
     $colon_pos = strpos($header_arr[$i], ':');
+    if ($colon_pos === false) continue;
 
     $name_substr = substr($header_arr[$i], 0, $colon_pos);
-    $name = $lc_header_names ? strtolower( $name_substr ) : $name_substr;
-    $value = trim( substr($header_arr[$i], $colon_pos + 1) );
+    $name = $lc_header_names ? strtolower($name_substr) : $name_substr;
+    $value = trim(substr($header_arr[$i], $colon_pos + 1));
 
-    $parsed_response['headers'][$name] = $value;
+    // Support multiple Set-Cookie headers
+    if (strtolower($name_substr) === 'set-cookie') {
+      if (!isset($parsed_response['headers']['set-cookie'])) {
+        $parsed_response['headers']['set-cookie'] = [];
+      }
+      $parsed_response['headers']['set-cookie'][] = $value;
+    } else {
+      $parsed_response['headers'][$name] = $value;
+    }
   }
-
   // Parse body (remaining) portion.
   $parsed_response['body'] = substr($response, $curl_info['header_size']);
-
 
   return $parsed_response;
 }
 
 function call_folio_api($api, $curl_options, $lc_header_names = true, $renewal_attempted = false) {
-
   global $folio_okapi_domain;
   global $folio_okapi_token;
 
   $all_options = $curl_options + array(
-      CURLOPT_RETURNTRANSFER => true,
-      CURLOPT_TIMEOUT => 30,
-      CURLOPT_HEADER => true,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_TIMEOUT => 30,
+    CURLOPT_HEADER => true,
+    CURLOPT_SSL_VERIFYPEER => false,
+    CURLOPT_SSL_VERIFYHOST => false,
   );
-
-
   // Set up and send FOLIO API request using PHP cURL extension.
-  $request_url = "https://{$folio_okapi_domain}{$api}";
-
+  $request_url = "https://" . $folio_okapi_domain . $api;
   $ch = curl_init($request_url);
 
   if ($ch === false) {
     return array('error' => 'PHP ERROR: curl_init() failure');
   }
 
-  if ( !curl_setopt_array($ch, $all_options) ) {
+  if (!curl_setopt_array($ch, $all_options)) {
     $curl_error = curl_error($ch);
     curl_close($ch);
-    return array( 'error' => 'PHP ERROR: curl_setopt_array() failure - ' . $curl_error );
+    return array('error' => 'PHP ERROR: curl_setopt_array() failure - ' . $curl_error);
   }
 
   $response = curl_exec($ch);
-
   $curl_info = curl_getinfo($ch);
 
   if ($curl_info === false) {
     $curl_error = curl_error($ch);
     curl_close($ch);
-    return array( 'error' => 'PHP ERROR: curl_getinfo() failure - ' . $curl_error );
+    return array('error' => 'PHP ERROR: curl_getinfo() failure - ' . $curl_error);
   }
+
+  curl_close($ch);
 
   $parsed_response = parse_http_response($response, $curl_info, $lc_header_names);
 
-  if (trim( strtolower($parsed_response['body']) ) === 'invalid token') {
+  if (trim(strtolower($parsed_response['body'])) === 'invalid token') {
     if ($renewal_attempted) {
-      return array( 'error' => 'FOLIO ERROR: Invalid token' );
+      return array('error' => 'FOLIO ERROR: Invalid token');
     }
 
     $cacheObj = get_folio_okapi_token(true);
 
     if ($cacheObj->error) {
-      return array( 'error' => 'FOLIO ERROR: Token renewal failure' );
+      return array('error' => 'FOLIO ERROR: Token renewal failure');
     }
 
     $folio_okapi_token = $cacheObj->token;
-
-    return call_folio_api($api, $curl_options, $lc_header_names, $renewal_attempted);
+    return call_folio_api($api, $curl_options, $lc_header_names, true);
   }
 
   return $parsed_response;
 }
 
 function login() {
-
   global $folio_okapi_tenant;
   global $folio_username;
   global $folio_password;
 
-
   // Call FOLIO /authn/login API to request new Okapi token.
   $request_headers = array(
-      'Content-type: application/json',
-      "X-Okapi-Tenant: {$folio_okapi_tenant}",
+    'Content-type: application/json',
+    "X-Okapi-Tenant: {$folio_okapi_tenant}",
   );
 
   $jsonObj = new stdClass();
@@ -116,29 +109,26 @@ function login() {
   $json = json_encode($jsonObj);
 
   $curl_options = array(
-      CURLOPT_POST => true,
-      CURLOPT_HTTPHEADER => $request_headers,
-      CURLOPT_FRESH_CONNECT => true,
-      CURLOPT_FORBID_REUSE => true,
-      CURLOPT_POSTFIELDS => $json,
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => $request_headers,
+    CURLOPT_FRESH_CONNECT => true,
+    CURLOPT_FORBID_REUSE => true,
+    CURLOPT_POSTFIELDS => $json,
+    CURLOPT_RETURNTRANSFER => true
   );
 
-
-  return call_folio_api('/authn/login', $curl_options);
+  return call_folio_api('/authn/login-with-expiry', $curl_options);
 }
 
 function get_folio_okapi_token($force_new = false) {
-
   global $token_expiration_days;
 
   $cache_file = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'cache.json';
-
   $cacheObj = null;
   $cache_json = file_get_contents($cache_file);
 
-
   // Set token object to cache file contents or new object if unable.
-  if ( $force_new || ($cache_json === false) || empty($cache_json) ) {
+  if ($force_new || $cache_json === false || empty($cache_json)) {
     $cacheObj = new stdClass();
   } else {
     $cacheObj = json_decode($cache_json);
@@ -147,23 +137,37 @@ function get_folio_okapi_token($force_new = false) {
   // Create/overwrite cache file if forced, json_decode() failed, the token has
   // no assigned expiration time, the token has expired, or the cached token is
   // empty.
-  if ( is_null($cacheObj) || empty($cacheObj->tokenExpires) || (time() > $cacheObj->tokenExpires) || empty($cacheObj->token) ) {
+  if (is_null($cacheObj) || empty($cacheObj->tokenExpires) || time() > $cacheObj->tokenExpires || empty($cacheObj->token)) {
     $login_response = login();
 
-    if ( empty($login_response['error']) ) {
+    if (!empty($login_response['headers']['set-cookie'])) {
+      foreach ($login_response['headers']['set-cookie'] as $cookieHeader) {
+        if (stripos($cookieHeader, 'folioAccessToken=') !== false) {
+          parse_str(str_replace(';', '&', $cookieHeader), $parsedCookie);
+          if (isset($parsedCookie['folioAccessToken'])) {
+            $cacheObj->token = $parsedCookie['folioAccessToken'];
+          }
+        }
+      }
+    }
+
+
+    // Fallback to X-Okapi-Token if folioAccessToken not found
+    if (empty($cacheObj->token) && isset($login_response['headers']['x-okapi-token'])) {
       $cacheObj->token = $login_response['headers']['x-okapi-token'];
+    }
+
+    if (!empty($cacheObj->token)) {
       $cacheObj->tokenExpires = time() + (86400 * $token_expiration_days);
+      $cache_json = json_encode($cacheObj);
+      if (is_writable($cache_file)) {
+        file_put_contents($cache_file, $cache_json);
+      }
     } else {
-      $cacheObj->error = $login_response['error'];
+      $cacheObj->error = $login_response['error'] ?? 'Token not found';
     }
 
-    $cache_json = json_encode($cacheObj);
-
-    if ( is_writable($cache_file) ) {
-      file_put_contents($cache_file, $cache_json);
-    }
   }
-
 
   return $cacheObj;
 }


### PR DESCRIPTION
Please describe the problem you'd like to be solved:
In the upcoming Sunflower Release of FOLIO, non-expiring tokens will no longer be supported. ([RTR docs](https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/1396980/Refresh+Token+Rotation+RTR)). The authentication method authn/login will be removed from the login module.

Describe the solution you'd like to see implemented:
I believe there will be a lot of libraries needing to update their current folio-spineomatic middleware solution to be able to support token retrieval from the current authentication method [authn/login-with-expiry](https://s3.amazonaws.com/foliodocs/api/mod-login/p/login.html#authn_login_with_expiry_post)

Describe alternatives you've considered:
Since a request for the XML of an item only happens when a barcode is scanned, updating the codebase to authenticate at authn/login-with-expiry for each request should suffice. This is suggested in the documentation for refresh token rotation underneath the section titled:
"A guide for non-module clients such as scripts or other integrations".

Token retrieval from set-cookie response headers will also need to be implemented since tokens no longer will be sent in the response body.

Additional context:
[FOLIO Release Cycle](https://folio-org.atlassian.net/wiki/spaces/REL/overview)